### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It's configuration keys in sqlboiler are simple:
 # sqlite3 is being run can change.
 # For example generation time and model test time.
 [sqlite3]
-db_name = "/path/to/file"
+dbname = "/path/to/file"
 ```
 
 ## Development


### PR DESCRIPTION
Fixed typo in readme which resulted in error:
```
 λ sqlboiler sqlite3
failed to find key dbname in config
Error: unable to initialize tables: unable to fetch table data: driver
```