### PR TITLE
Handle unique partial indices properly

### DIFF
--- a/driver/sqlite3.go
+++ b/driver/sqlite3.go
@@ -315,7 +315,8 @@ ColumnLoop:
 			}
 			for _, name := range idx.Columns {
 				if name == column.Name {
-					bColumn.Unique = idx.Unique > 0
+					// A column is unique if it has a unique non-partial index
+					bColumn.Unique = idx.Unique > 0 && idx.Partial == 0
 				}
 			}
 		}


### PR DESCRIPTION
Only treat a column as being unique if the index is unique and not a partial index.

Fixes #14 